### PR TITLE
发布后端 Agent 分架构安装包

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,35 +83,29 @@ flowchart LR
 
 ## 快速安装
 
-正式发布通过 GitHub Releases 提供编译包，不要求客户下载源码。
+平台前端源码保存在本仓库，后端 Agent 只通过 GitHub Releases 和国内镜像提供编译包，不上传后端源码，也不上传前端 Docker 镜像。
 
 下载地址：
 
 - [GitHub Release](https://github.com/st-lzh/Wuhr-AI-ops/releases/tag/v1.0.0)
 - [国内下载镜像](http://106.12.150.207/download/)
 
+在受管服务器安装后端 Agent：
+
 ```bash
-sha256sum -c wuhr-ai-ops-1.0.0.tar.gz.sha256
-tar -xzf wuhr-ai-ops-1.0.0.tar.gz
-cd wuhr-ai-ops-1.0.0
-sudo ./install.sh all
+tmp=$(mktemp) && trap 'rm -f "$tmp"' 0 HUP INT TERM \
+  && (curl -fsSL 'https://github.com/st-lzh/Wuhr-AI-ops/releases/download/v1.0.0/install-agent.sh' -o "$tmp" \
+  || curl -fsSL 'http://106.12.150.207/download/install-agent.sh' -o "$tmp") \
+  && sudo sh "$tmp" --port=2081
 ```
 
-安装完成后访问 `http://服务器地址:3000`。初始随机密码保存在服务器 `/opt/wuhr-ai-ops/initial-credentials.txt`，首次登录后必须修改密码并删除该文件。
+下载器会识别 Linux/macOS 与 amd64/arm64，优先从 GitHub 下载对应后端包；GitHub 不可用、校验失败或超时时自动改用国内镜像。
 
 平台与 Agent 分机部署、TLS、防火墙、升级、诊断和卸载说明见[安装与升级手册](./docs/INSTALLATION.md)。
 
 ## 发布物与源码边界
 
-客户发布包只包含：
-
-- 前端平台 Docker 镜像归档
-- PostgreSQL 与 Redis 运行镜像
-- Linux/macOS、amd64/arm64 的 Wuhr Agent 二进制
-- 一键安装、诊断、升级回滚和卸载脚本
-- `SHA256SUMS`、发布清单与使用文档
-
-发布构建器会拒绝把 `.go`、`.ts`、`.tsx`、source map、`.env`、私钥或 `.git` 放入客户包。Docker 镜像只保留 Next.js 编译运行产物、数据库迁移、初始化数据与运行依赖。
+公开 Release 只包含 Linux/macOS、amd64/arm64 的 Wuhr Agent 分架构包、安装器与 SHA-256 校验文件。发布构建器会拒绝把 `.go`、`.ts`、`.tsx`、source map、`.env`、私钥或 `.git` 放入后端交付包。
 
 ## 浏览器与系统要求
 

--- a/app/api/admin/servers/route.ts
+++ b/app/api/admin/servers/route.ts
@@ -7,6 +7,7 @@ import { withLeakDetection } from '../../../../lib/database/leakDetector'
 import { ServerStatus } from '../../../../lib/generated/prisma'
 import { protectSecret, revealSecret } from '../../../../lib/crypto/encryption'
 import { canWriteTeamAssets } from '../../../../lib/auth/teamAccess'
+import { buildAgentInstallCommand } from '../../../../lib/agentRelease'
 
 // 响应辅助函数
 function successResponse(data: any) {
@@ -304,7 +305,7 @@ export async function POST(request: NextRequest) {
         await sshClient.connect()
 
         // 下载并执行安装脚本
-        const installCommand = `curl -fsSL https://www.wuhrai.com/download/v2.0.0/install-kubelet-wuhrai.sh | bash -s -- --port=2081`
+        const installCommand = buildAgentInstallCommand(2081)
 
         console.log('📥 执行安装命令:', installCommand)
         const installResult = await sshClient.executeCommand(installCommand)

--- a/app/api/servers/[id]/check-kubelet-wuhrai/route.ts
+++ b/app/api/servers/[id]/check-kubelet-wuhrai/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { buildAgentInstallCommand } from '../../../../../lib/agentRelease'
 import { requireAuth } from '../../../../../lib/auth/apiHelpers-new'
 import { getPrismaClient } from '../../../../../lib/config/database'
 
@@ -104,7 +105,7 @@ export async function GET(
 
         recommendations.push({
           type: 'info',
-          message: `curl -fsSL https://www.wuhrai.com/download/v2.0.0/install-kubelet-wuhrai.sh | bash -s -- --port=${kubeletPort}`
+          message: buildAgentInstallCommand(kubeletPort)
         })
       }
 

--- a/app/api/servers/[id]/install-kubelet-wuhrai/route.ts
+++ b/app/api/servers/[id]/install-kubelet-wuhrai/route.ts
@@ -4,9 +4,7 @@ import { getPrismaClient } from '../../../../../lib/config/database'
 import {
   createSSHConfigFromServer
 } from '../../../../../lib/utils/sshConnectionUtils'
-
-// kubelet-wuhrai 安装脚本URL
-const INSTALL_SCRIPT_URL = 'https://www.wuhrai.com/download/v2.0.0/install-kubelet-wuhrai.sh'
+import { buildAgentInstallCommand } from '../../../../../lib/agentRelease'
 
 export async function POST(
   request: NextRequest,
@@ -132,7 +130,7 @@ export async function POST(
         installLogs.push('📥 开始下载并执行安装脚本...')
 
         // 构建安装命令
-        const installCommand = `curl -fsSL ${INSTALL_SCRIPT_URL} | bash -s -- --port=${kubeletPort} 2>&1`
+        const installCommand = `${buildAgentInstallCommand(kubeletPort)} 2>&1`
 
         installLogs.push(`执行: ${installCommand}`)
 

--- a/app/components/ai/AgentStreamRenderer.tsx
+++ b/app/components/ai/AgentStreamRenderer.tsx
@@ -14,6 +14,7 @@ import {
   WarningOutlined
 } from '@ant-design/icons'
 import { approveCommand, rejectCommand } from '@/utils/httpApiClient'
+import { buildAgentInstallCommand } from '@/lib/agentRelease'
 
 const { Text, Paragraph } = Typography
 
@@ -325,7 +326,7 @@ const AgentStreamRenderer: React.FC<AgentStreamRendererProps> = ({
                       <div className="bg-gray-100 dark:bg-gray-800 p-2 rounded mb-2">
                         <div className="text-xs text-gray-600 dark:text-gray-400 mb-1">安装命令：</div>
                         <code className="text-xs text-gray-800 dark:text-gray-200 block overflow-x-auto">
-                          curl -fsSL https://www.wuhrai.com/download/v2.0.0/install-kubelet-wuhrai.sh | bash -s -- --port=2081
+                          {buildAgentInstallCommand(2081)}
                         </code>
                       </div>
 

--- a/app/components/ai/SystemChat.tsx
+++ b/app/components/ai/SystemChat.tsx
@@ -95,6 +95,7 @@ import HostMentionInput, { ChatTargetCluster, ChatTargetDevice, ChatTargetHost, 
 import DeliveryContextPanel, { catalogToMentionOptions } from './DeliveryContextPanel'
 import type { CICDCatalog, CICDContextSelection, CICDMentionOption } from '../../types/cicd-ai'
 import { useTheme } from '../../hooks/useGlobalState'
+import { buildAgentInstallCommand } from '../../../lib/agentRelease'
 
 
 const { Text, Title } = Typography
@@ -898,7 +899,7 @@ const SystemChat: React.FC = () => {
                       或手动在服务器上执行以下命令：
                     </div>
                     <div className="p-2 bg-transparent border border-gray-600/30 rounded text-sm text-gray-400 font-mono">
-                      curl -fsSL https://www.wuhrai.com/download/v2.0.0/install-kubelet-wuhrai.sh | bash -s -- --port=2081
+                      {buildAgentInstallCommand(2081)}
                     </div>
                   </div>
                 </div>

--- a/app/components/servers/ServerFormModal.tsx
+++ b/app/components/servers/ServerFormModal.tsx
@@ -18,6 +18,7 @@ import { ServerInfo, ServerFormData } from '../../types/access-management'
 import ServerFormFields from './ServerFormFields'
 import ServerTagManager from './ServerTagManager'
 import ServerConnectionTest from './ServerConnectionTest'
+import { buildAgentInstallCommand } from '../../../lib/agentRelease'
 
 interface ServerFormModalProps {
   visible: boolean
@@ -220,7 +221,7 @@ const ServerFormModal: React.FC<ServerFormModalProps> = ({
               {() => {
                 const values = form.getFieldsValue()
                 const kubeletPort = values.kubeletPort || 2081
-                const installCommand = `curl -fsSL https://www.wuhrai.com/download/v2.0.0/install-kubelet-wuhrai.sh | bash -s -- --port=${kubeletPort}`
+                const installCommand = buildAgentInstallCommand(kubeletPort)
 
                 return values.ip && values.username ? (
                   <Alert

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,6 +1,6 @@
 # Wuhr AI Ops 安装与升级手册
 
-本文面向拿到正式发布包的系统管理员。发布包只包含前端运行镜像、Wuhr Agent 编译后二进制、安装脚本和校验文件，不包含前后端源码。
+本文面向平台与 Agent 系统管理员。公开 Release 只包含 Wuhr Agent 编译后二进制、安装脚本和校验文件，不包含后端源码，也不包含前端 Docker 镜像。
 
 ## 1. 部署结构
 
@@ -37,23 +37,32 @@ Agent 支持：
 - GitHub：`https://github.com/st-lzh/Wuhr-AI-ops/releases/tag/v1.0.0`
 - 国内镜像：`http://106.12.150.207/download/`
 
-完整平台请选择 `wuhr-ai-ops-1.0.0.tar.gz`；仅安装 Agent 请选择
-`wuhr-agent-1.0.0.tar.gz`。两个压缩包都必须同时下载对应的 `.sha256`
-文件进行校验。
+Agent 按操作系统和 CPU 架构分为四个包：
+
+- `wuhr-agent-1.0.0-linux-amd64.tar.gz`
+- `wuhr-agent-1.0.0-linux-arm64.tar.gz`
+- `wuhr-agent-1.0.0-darwin-amd64.tar.gz`
+- `wuhr-agent-1.0.0-darwin-arm64.tar.gz`
+
+推荐直接使用在线安装器。它先访问 GitHub，失败或校验不通过时自动切换国内镜像：
 
 ```bash
-sha256sum -c wuhr-ai-ops-1.0.0.tar.gz.sha256
-tar -xzf wuhr-ai-ops-1.0.0.tar.gz
-cd wuhr-ai-ops-1.0.0
+tmp=$(mktemp) && trap 'rm -f "$tmp"' 0 HUP INT TERM \
+  && (curl -fsSL 'https://github.com/st-lzh/Wuhr-AI-ops/releases/download/v1.0.0/install-agent.sh' -o "$tmp" \
+  || curl -fsSL 'http://106.12.150.207/download/install-agent.sh' -o "$tmp") \
+  && sudo sh "$tmp" --port=2081
 ```
 
-macOS 可使用：
+手动下载时必须同时下载对应的 `.sha256` 文件。例如：
 
 ```bash
-shasum -a 256 -c wuhr-ai-ops-1.0.0.tar.gz.sha256
+sha256sum -c wuhr-agent-1.0.0-linux-amd64.tar.gz.sha256
+tar -xzf wuhr-agent-1.0.0-linux-amd64.tar.gz
+cd wuhr-agent-1.0.0-linux-amd64
+sudo ./install-agent.sh --port=2081
 ```
 
-不要安装校验失败的文件。
+macOS 使用 `shasum -a 256 -c 文件名.sha256`。不要安装校验失败的文件。
 
 ## 4. 一键同机安装
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -22,75 +22,74 @@
 
 ## 正式构建
 
-在前端仓库根目录运行：
+公开 GitHub Release 只构建后端 Agent，不构建或上传前端镜像。在前端仓库根目录运行：
 
 ```bash
-./packaging/build-release.sh --version 1.0.0
+./packaging/build-agent-release.sh --version 1.0.0
 ```
 
 构建器会按顺序执行：
 
 1. 检查安装脚本语法与发布文件凭据边界。
-2. 拒绝未提交的 Git 工作区。
-3. 运行前端单元测试、TypeScript 检查和 Agent 全量 Go 测试。
-4. 构建 linux/amd64 与 linux/arm64 前端运行镜像。
-5. 交叉编译四种 Agent 二进制。
-6. 导出各架构的前端、PostgreSQL 与 Redis 离线镜像。
-7. 扫描发布目录，拒绝源码、source map、环境文件和私钥。
-8. 生成文件级 `SHA256SUMS`、发布压缩包与压缩包校验文件。
+2. 运行 Agent 全量 Go 测试。
+3. 交叉编译 Linux/macOS、amd64/arm64 四种 Agent 二进制。
+4. 每个系统架构生成独立压缩包。
+5. 扫描发布目录，拒绝源码、source map、环境文件和私钥。
+6. 生成在线下载器和每个文件的 SHA-256 校验文件。
 
 输出：
 
 ```text
-dist/wuhr-ai-ops-1.0.0.tar.gz
-dist/wuhr-ai-ops-1.0.0.tar.gz.sha256
-dist/wuhr-agent-1.0.0.tar.gz
-dist/wuhr-agent-1.0.0.tar.gz.sha256
+dist/agent/install-agent.sh
+dist/agent/install-agent.sh.sha256
+dist/agent/wuhr-agent-1.0.0-linux-amd64.tar.gz
+dist/agent/wuhr-agent-1.0.0-linux-amd64.tar.gz.sha256
+dist/agent/wuhr-agent-1.0.0-linux-arm64.tar.gz
+dist/agent/wuhr-agent-1.0.0-linux-arm64.tar.gz.sha256
+dist/agent/wuhr-agent-1.0.0-darwin-amd64.tar.gz
+dist/agent/wuhr-agent-1.0.0-darwin-amd64.tar.gz.sha256
+dist/agent/wuhr-agent-1.0.0-darwin-arm64.tar.gz
+dist/agent/wuhr-agent-1.0.0-darwin-arm64.tar.gz.sha256
 ```
+
+安装器根据 `uname` 选择其中一个包，优先使用 GitHub Release，失败或 SHA-256 不匹配时改用 `http://106.12.150.207/download/`。
+
+## 平台离线包
+
+`packaging/build-release.sh` 仍可供内部或私有交付构建完整平台离线包，但该产物不得上传到公开 GitHub Release 或国内 `/download/` 目录。
 
 ## 内部预览构建
 
 只有内部验证可以允许未提交工作区：
 
 ```bash
-./packaging/build-release.sh \
-  --version 1.0.0-review \
-  --architectures arm64 \
-  --reuse-image wuhr-ai-ops:local \
-  --use-local-dependency-images \
-  --skip-tests \
-  --allow-dirty
+./packaging/build-agent-release.sh --version 1.0.0-review --skip-tests
 ```
 
-`--skip-tests`、`--reuse-image`、`--allow-dirty` 不应出现在正式发布流水线。
-
-只检查脚本和发布边界：
-
-```bash
-./packaging/build-release.sh --validate-only
-```
+`--skip-tests` 不应出现在正式发布流水线。
 
 ## 发布前验收
 
 ```bash
-shasum -a 256 -c dist/wuhr-ai-ops-1.0.0.tar.gz.sha256
-tar -tzf dist/wuhr-ai-ops-1.0.0.tar.gz
+for checksum in dist/agent/*.sha256; do
+  (cd dist/agent && shasum -a 256 -c "$(basename "$checksum")")
+done
+tar -tzf dist/agent/wuhr-agent-1.0.0-linux-amd64.tar.gz
 ```
 
-必须在干净的 amd64 和 arm64 Linux 虚拟机各执行一次：
+必须在干净的 amd64 和 arm64 Linux 虚拟机各执行一次，macOS 包也要完成解压和 `--dry-run` 验证：
 
 ```bash
-sudo ./install.sh all
+sudo ./install-agent.sh --port=2081
 sudo ./doctor.sh
 ```
 
 验收内容：
 
-- 首次安装成功，四个 Docker 核心服务与 Agent 系统服务均健康。
-- 随机管理员密码可登录，删除凭据文件后不影响重启。
+- 首次安装成功，Agent 系统服务健康。
 - Agent 拒绝无效 API Key，安全控制与人工审批默认开启。
-- 重复安装不会清空数据库、Redis、审批、作业、交付、经验或审计数据。
-- 人为替换一个损坏镜像/Agent 后，安装器能报告失败并恢复旧版本。
+- 重复安装不会清空 Agent 配置、经验或审计数据。
+- 人为替换一个损坏 Agent 后，安装器能报告失败并恢复旧版本。
 - `--purge` 之外的卸载不会删除业务数据。
 
 ## GitHub Release 上传
@@ -98,10 +97,16 @@ sudo ./doctor.sh
 确认产物后，只上传：
 
 ```text
-wuhr-ai-ops-VERSION.tar.gz
-wuhr-ai-ops-VERSION.tar.gz.sha256
-wuhr-agent-VERSION.tar.gz
-wuhr-agent-VERSION.tar.gz.sha256
+install-agent.sh
+install-agent.sh.sha256
+wuhr-agent-VERSION-linux-amd64.tar.gz
+wuhr-agent-VERSION-linux-amd64.tar.gz.sha256
+wuhr-agent-VERSION-linux-arm64.tar.gz
+wuhr-agent-VERSION-linux-arm64.tar.gz.sha256
+wuhr-agent-VERSION-darwin-amd64.tar.gz
+wuhr-agent-VERSION-darwin-amd64.tar.gz.sha256
+wuhr-agent-VERSION-darwin-arm64.tar.gz
+wuhr-agent-VERSION-darwin-arm64.tar.gz.sha256
 ```
 
-不要上传源码自动归档、源码压缩包、`.env`、客户日志或单独的未校验二进制。发布说明应列出版本、提交、支持架构、数据库迁移影响、已知限制和升级步骤。
+不要上传前端镜像、完整平台离线包、后端源码、源码自动归档、`.env`、客户日志或单独的未校验二进制。发布说明应列出版本、后端来源摘要、支持架构、已知限制和升级步骤。

--- a/lib/agentRelease.ts
+++ b/lib/agentRelease.ts
@@ -1,0 +1,25 @@
+export const AGENT_RELEASE_VERSION = '1.0.0'
+
+export const AGENT_INSTALLER_PRIMARY_URL =
+  `https://github.com/st-lzh/Wuhr-AI-ops/releases/download/v${AGENT_RELEASE_VERSION}/install-agent.sh`
+
+export const AGENT_INSTALLER_MIRROR_URL =
+  'http://106.12.150.207/download/install-agent.sh'
+
+/**
+ * 生成不会直接把远程内容管道给 shell 的 Agent 安装命令。
+ * GitHub 不可用时会自动切换到国内镜像，两个来源使用完全相同的安装脚本。
+ */
+export function buildAgentInstallCommand(port: number = 2081): string {
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new Error('Agent 端口必须是 1-65535 的整数')
+  }
+
+  return [
+    'tmp=$(mktemp)',
+    `trap 'rm -f "$tmp"' 0 HUP INT TERM`,
+    `(curl -fsSL '${AGENT_INSTALLER_PRIMARY_URL}' -o "$tmp"`,
+    `|| curl -fsSL '${AGENT_INSTALLER_MIRROR_URL}' -o "$tmp")`,
+    `sh "$tmp" --port=${port}`
+  ].join(' && ')
+}

--- a/packaging/build-agent-release.sh
+++ b/packaging/build-agent-release.sh
@@ -1,0 +1,224 @@
+#!/bin/sh
+set -eu
+
+ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+BACKEND_DIR=${WUHR_BACKEND_DIR:-"$ROOT_DIR/../v1/backend"}
+OUTPUT_DIR=${WUHR_RELEASE_OUTPUT_DIR:-"$ROOT_DIR/dist/agent"}
+RUNTIME_DIR="$ROOT_DIR/packaging/runtime"
+VERSION=""
+TARGETS="linux-amd64,linux-arm64,darwin-amd64,darwin-arm64"
+SKIP_TESTS=0
+
+log() {
+  printf '%s\n' "[agent-release] $*"
+}
+
+die() {
+  printf '%s\n' "[agent-release][错误] $*" >&2
+  exit 1
+}
+
+checksum_file() {
+  file=$1
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$file"
+  else
+    shasum -a 256 "$file"
+  fi
+}
+
+checksum_stream() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum | awk '{print $1}'
+  else
+    shasum -a 256 | awk '{print $1}'
+  fi
+}
+
+usage() {
+  cat <<'EOF'
+用法：./packaging/build-agent-release.sh [选项]
+
+选项：
+  --version VERSION      发布版本，默认读取 package.json
+  --targets LIST         默认 linux-amd64,linux-arm64,darwin-amd64,darwin-arm64
+  --backend-dir PATH     Agent 源码目录
+  --output-dir PATH      输出目录，默认 ./dist/agent
+  --skip-tests           跳过 Go 测试（正式发布不建议）
+  -h, --help             显示帮助
+
+本脚本只生成编译后的后端 Agent 分架构包，不构建、不导出前端 Docker 镜像。
+EOF
+}
+
+need_value() {
+  [ "$#" -ge 2 ] || die "参数 $1 缺少值"
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --version)
+      need_value "$@"
+      VERSION=$2
+      shift 2
+      ;;
+    --targets)
+      need_value "$@"
+      TARGETS=$2
+      shift 2
+      ;;
+    --backend-dir)
+      need_value "$@"
+      BACKEND_DIR=$2
+      shift 2
+      ;;
+    --output-dir)
+      need_value "$@"
+      OUTPUT_DIR=$2
+      shift 2
+      ;;
+    --skip-tests)
+      SKIP_TESTS=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "未知参数：$1"
+      ;;
+  esac
+done
+
+if [ -z "$VERSION" ]; then
+  VERSION=$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$ROOT_DIR/package.json" | head -n 1)
+fi
+case "$VERSION" in
+  ''|*[!A-Za-z0-9._-]*) die "版本号为空或含有非法字符：$VERSION" ;;
+esac
+
+[ -f "$BACKEND_DIR/go.mod" ] || die "Agent 目录缺少 go.mod：$BACKEND_DIR"
+for command_name in go gzip tar; do
+  command -v "$command_name" >/dev/null 2>&1 || die "缺少构建命令：$command_name"
+done
+for file in install-agent.sh uninstall-agent.sh doctor.sh install-agent-bootstrap.sh; do
+  [ -f "$RUNTIME_DIR/$file" ] || die "发布运行时缺少 $file"
+done
+for script in "$RUNTIME_DIR/install-agent.sh" "$RUNTIME_DIR/uninstall-agent.sh" \
+  "$RUNTIME_DIR/doctor.sh" "$RUNTIME_DIR/install-agent-bootstrap.sh" "$0"; do
+  sh -n "$script" || die "Shell 语法检查失败：$script"
+done
+
+OLD_IFS=$IFS
+IFS=','
+for target in $TARGETS; do
+  case "$target" in
+    linux-amd64|linux-arm64|darwin-amd64|darwin-arm64) ;;
+    *) die "不支持的目标：$target" ;;
+  esac
+done
+IFS=$OLD_IFS
+
+if [ "$SKIP_TESTS" -eq 0 ]; then
+  log "运行 Agent Go 测试"
+  (
+    cd "$BACKEND_DIR"
+    go test ./...
+  )
+fi
+
+AGENT_SOURCE_SHA256=$(
+  cd "$BACKEND_DIR"
+  find . -type f \( -name '*.go' -o -name 'go.mod' -o -name 'go.sum' \) -print |
+    LC_ALL=C sort |
+    while IFS= read -r source_file; do
+      checksum_file "$source_file"
+    done |
+    checksum_stream
+)
+AGENT_COMMIT=$(git -C "$BACKEND_DIR" rev-parse --short=12 HEAD 2>/dev/null || true)
+if [ -z "$AGENT_COMMIT" ]; then
+  AGENT_COMMIT="source-$(printf '%s' "$AGENT_SOURCE_SHA256" | cut -c1-12)"
+fi
+BUILD_DATE=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+
+mkdir -p "$OUTPUT_DIR"
+rm -rf "$OUTPUT_DIR/.stage"
+mkdir -p "$OUTPUT_DIR/.stage"
+
+OLD_IFS=$IFS
+IFS=','
+for target in $TARGETS; do
+  IFS=$OLD_IFS
+  goos=${target%-*}
+  goarch=${target#*-}
+  release_name="wuhr-agent-$VERSION-$target"
+  stage="$OUTPUT_DIR/.stage/$release_name"
+  archive="$OUTPUT_DIR/$release_name.tar.gz"
+
+  log "构建 $target"
+  mkdir -p "$stage/agent/bin"
+  (
+    cd "$BACKEND_DIR"
+    CGO_ENABLED=0 GOOS="$goos" GOARCH="$goarch" \
+      go build -trimpath \
+      -ldflags "-s -w -X main.version=$VERSION -X main.commit=$AGENT_COMMIT -X main.date=$BUILD_DATE" \
+      -o "$stage/agent/bin/kubelet-wuhrai-$target" ./cmd
+  )
+
+  cp "$RUNTIME_DIR/install-agent.sh" "$RUNTIME_DIR/uninstall-agent.sh" \
+    "$RUNTIME_DIR/doctor.sh" "$stage/"
+  chmod 0755 "$stage"/*.sh "$stage/agent/bin/kubelet-wuhrai-$target"
+
+  cat > "$stage/release.json" <<EOF
+{
+  "product": "Wuhr Agent",
+  "version": "$VERSION",
+  "target": "$target",
+  "agentCommit": "$AGENT_COMMIT",
+  "agentSourceSha256": "$AGENT_SOURCE_SHA256",
+  "buildDate": "$BUILD_DATE",
+  "sourceIncluded": false
+}
+EOF
+
+  if find "$stage" -type f \( -name '*.go' -o -name '*.ts' -o -name '*.tsx' \
+    -o -name '*.map' -o -name '.env' -o -name '*.pem' -o -name '*.key' \) |
+    grep -q .; then
+    die "$target 发布目录中发现源码、环境文件或私钥"
+  fi
+
+  (
+    cd "$stage"
+    find . -type f ! -name SHA256SUMS -print | LC_ALL=C sort |
+      while IFS= read -r file; do
+        checksum_file "$file"
+      done > SHA256SUMS
+  )
+
+  rm -f "$archive" "$archive.sha256"
+  tar -C "$OUTPUT_DIR/.stage" -czf "$archive" "$release_name"
+  (
+    cd "$OUTPUT_DIR"
+    checksum_file "$release_name.tar.gz" > "$release_name.tar.gz.sha256"
+  )
+
+  if tar -tzf "$archive" |
+    grep -E '\.(go|ts|tsx|map)$|/(^|\.)(env|git)(/|$)' >/dev/null 2>&1; then
+    die "$archive 中发现不应交付的源码或环境文件"
+  fi
+  IFS=','
+done
+IFS=$OLD_IFS
+
+cp "$RUNTIME_DIR/install-agent-bootstrap.sh" "$OUTPUT_DIR/install-agent.sh"
+chmod 0755 "$OUTPUT_DIR/install-agent.sh"
+(
+  cd "$OUTPUT_DIR"
+  checksum_file "install-agent.sh" > "install-agent.sh.sha256"
+)
+rm -rf "$OUTPUT_DIR/.stage"
+
+log "后端 Agent 分架构发布包已生成：$OUTPUT_DIR"
+log "发布目录不包含前端镜像、前端源码或后端源码"

--- a/packaging/build-agent-release.sh
+++ b/packaging/build-agent-release.sh
@@ -198,7 +198,7 @@ EOF
   )
 
   rm -f "$archive" "$archive.sha256"
-  tar -C "$OUTPUT_DIR/.stage" -czf "$archive" "$release_name"
+  COPYFILE_DISABLE=1 tar --no-xattrs -C "$OUTPUT_DIR/.stage" -czf "$archive" "$release_name"
   (
     cd "$OUTPUT_DIR"
     checksum_file "$release_name.tar.gz" > "$release_name.tar.gz.sha256"

--- a/packaging/download-index.html
+++ b/packaging/download-index.html
@@ -34,37 +34,57 @@
   <main>
     <div class="eyebrow">China Download Mirror</div>
     <h1>Wuhr AI Ops v1.0.0</h1>
-    <p class="lead">国内下载镜像支持断点续传。完整平台包包含双架构离线 Docker 镜像和四平台 Agent；Agent 独立包只包含编译后二进制与系统服务安装器，不包含后端源码。</p>
+    <p class="lead">本镜像只提供编译后的 Wuhr Agent 后端包，不包含前端 Docker 镜像或后端源码。安装器会自动识别操作系统和 CPU 架构，并对下载内容执行 SHA-256 校验。</p>
 
     <div class="grid">
       <article class="card">
-        <h2>完整平台安装包</h2>
-        <div class="meta">约 967 MB · Linux amd64 / arm64</div>
-        <p>前端平台、PostgreSQL、Redis 离线镜像，Linux/macOS 四架构 Agent，以及一键安装、诊断和卸载脚本。</p>
+        <h2>Linux amd64</h2>
+        <div class="meta">Ubuntu / Debian / RHEL / CentOS / Rocky / Alpine</div>
+        <p>适用于 Intel、AMD 的 64 位 Linux，支持 systemd、OpenRC 和 SysV init。</p>
         <div class="actions">
-          <a class="button" href="./wuhr-ai-ops-1.0.0.tar.gz">下载平台包</a>
-          <a class="button secondary" href="./wuhr-ai-ops-1.0.0.tar.gz.sha256">SHA-256</a>
+          <a class="button" href="./wuhr-agent-1.0.0-linux-amd64.tar.gz">下载后端包</a>
+          <a class="button secondary" href="./wuhr-agent-1.0.0-linux-amd64.tar.gz.sha256">SHA-256</a>
         </div>
       </article>
 
       <article class="card">
-        <h2>Agent 独立安装包</h2>
-        <div class="meta">约 44 MB · Linux / macOS · amd64 / arm64</div>
-        <p>仅含编译后的 Agent、systemd/OpenRC/SysV/launchd 安装器、诊断和卸载脚本，适合受管主机单独安装。</p>
+        <h2>Linux arm64</h2>
+        <div class="meta">ARM 服务器 / 云主机</div>
+        <p>适用于 aarch64、arm64 的 64 位 Linux，支持 systemd、OpenRC 和 SysV init。</p>
         <div class="actions">
-          <a class="button" href="./wuhr-agent-1.0.0.tar.gz">下载 Agent 包</a>
-          <a class="button secondary" href="./wuhr-agent-1.0.0.tar.gz.sha256">SHA-256</a>
+          <a class="button" href="./wuhr-agent-1.0.0-linux-arm64.tar.gz">下载后端包</a>
+          <a class="button secondary" href="./wuhr-agent-1.0.0-linux-arm64.tar.gz.sha256">SHA-256</a>
+        </div>
+      </article>
+
+      <article class="card">
+        <h2>macOS amd64</h2>
+        <div class="meta">Intel Mac</div>
+        <p>适用于 Intel 处理器的 macOS，通过 launchd 注册并管理 Agent 系统服务。</p>
+        <div class="actions">
+          <a class="button" href="./wuhr-agent-1.0.0-darwin-amd64.tar.gz">下载后端包</a>
+          <a class="button secondary" href="./wuhr-agent-1.0.0-darwin-amd64.tar.gz.sha256">SHA-256</a>
+        </div>
+      </article>
+
+      <article class="card">
+        <h2>macOS arm64</h2>
+        <div class="meta">Apple Silicon</div>
+        <p>适用于 Apple M 系列芯片的 macOS，通过 launchd 注册并管理 Agent 系统服务。</p>
+        <div class="actions">
+          <a class="button" href="./wuhr-agent-1.0.0-darwin-arm64.tar.gz">下载后端包</a>
+          <a class="button secondary" href="./wuhr-agent-1.0.0-darwin-arm64.tar.gz.sha256">SHA-256</a>
         </div>
       </article>
     </div>
 
     <section class="note">
-      <h2>安装前先校验</h2>
-      <p>完整平台默认监听 <code>3000</code>，Agent 默认监听 <code>2081</code>。校验失败时不要解压或安装。</p>
-      <pre>sha256sum -c wuhr-ai-ops-1.0.0.tar.gz.sha256
-tar -xzf wuhr-ai-ops-1.0.0.tar.gz
-cd wuhr-ai-ops-1.0.0
-sudo ./install.sh all</pre>
+      <h2>自动识别并安装</h2>
+      <p>Agent 默认监听 <code>2081</code>。下列命令先获取 GitHub 安装器，GitHub 不可用时改用本镜像；安装器下载后端包时也会执行相同的回退和校验逻辑。</p>
+      <pre>tmp=$(mktemp) &amp;&amp; trap 'rm -f "$tmp"' 0 HUP INT TERM \
+  &amp;&amp; (curl -fsSL 'https://github.com/st-lzh/Wuhr-AI-ops/releases/download/v1.0.0/install-agent.sh' -o "$tmp" \
+  || curl -fsSL 'http://106.12.150.207/download/install-agent.sh' -o "$tmp") \
+  &amp;&amp; sudo sh "$tmp" --port=2081</pre>
     </section>
 
     <footer>

--- a/packaging/runtime/install-agent-bootstrap.sh
+++ b/packaging/runtime/install-agent-bootstrap.sh
@@ -4,7 +4,8 @@ set -eu
 VERSION=${WUHR_AGENT_VERSION:-1.0.0}
 GITHUB_BASE=${WUHR_AGENT_GITHUB_BASE:-"https://github.com/st-lzh/Wuhr-AI-ops/releases/download/v$VERSION"}
 MIRROR_BASE=${WUHR_AGENT_MIRROR_BASE:-"http://106.12.150.207/download"}
-DOWNLOAD_TIMEOUT=${WUHR_AGENT_DOWNLOAD_TIMEOUT:-30}
+GITHUB_TIMEOUT=${WUHR_AGENT_GITHUB_TIMEOUT:-30}
+MIRROR_TIMEOUT=${WUHR_AGENT_MIRROR_TIMEOUT:-180}
 TEMP_DIR=""
 
 log() {
@@ -31,10 +32,12 @@ trap cleanup 0 HUP INT TERM
 case "$VERSION" in
   ''|*[!A-Za-z0-9._-]*) die "版本号为空或含有非法字符：$VERSION" ;;
 esac
-case "$DOWNLOAD_TIMEOUT" in
-  ''|*[!0-9]*) die "下载超时必须是正整数秒数" ;;
-esac
-[ "$DOWNLOAD_TIMEOUT" -ge 1 ] || die "下载超时必须大于 0 秒"
+for timeout in "$GITHUB_TIMEOUT" "$MIRROR_TIMEOUT"; do
+  case "$timeout" in
+    ''|*[!0-9]*) die "下载超时必须是正整数秒数" ;;
+  esac
+  [ "$timeout" -ge 1 ] || die "下载超时必须大于 0 秒"
+done
 
 OS=$(uname -s)
 case "$OS" in
@@ -57,14 +60,15 @@ TEMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/wuhr-agent-download.XXXXXX")
 download_file() {
   url=$1
   output=$2
+  timeout=$3
 
   if command -v curl >/dev/null 2>&1; then
     curl --fail --location --silent --show-error \
-      --connect-timeout 10 --max-time "$DOWNLOAD_TIMEOUT" \
-      --retry 1 --retry-max-time "$DOWNLOAD_TIMEOUT" \
+      --connect-timeout 10 --max-time "$timeout" \
+      --retry 1 --retry-max-time "$timeout" \
       --output "$output" "$url"
   elif command -v wget >/dev/null 2>&1; then
-    wget --quiet --timeout=15 --read-timeout="$DOWNLOAD_TIMEOUT" \
+    wget --quiet --timeout=15 --read-timeout="$timeout" \
       --tries=2 --output-document="$output" "$url"
   else
     die "缺少下载工具，请先安装 curl 或 wget"
@@ -87,18 +91,19 @@ verify_package() {
 download_from() {
   base_url=$1
   source_name=$2
+  timeout=$3
 
   rm -f "$TEMP_DIR/$PACKAGE_NAME" "$TEMP_DIR/$CHECKSUM_NAME"
   log "正在从${source_name}下载 $PACKAGE_NAME"
-  download_file "$base_url/$PACKAGE_NAME" "$TEMP_DIR/$PACKAGE_NAME" || return 1
-  download_file "$base_url/$CHECKSUM_NAME" "$TEMP_DIR/$CHECKSUM_NAME" || return 1
+  download_file "$base_url/$PACKAGE_NAME" "$TEMP_DIR/$PACKAGE_NAME" "$timeout" || return 1
+  download_file "$base_url/$CHECKSUM_NAME" "$TEMP_DIR/$CHECKSUM_NAME" "$timeout" || return 1
   verify_package || return 1
   log "${source_name}下载及 SHA-256 校验通过"
 }
 
-if ! download_from "$GITHUB_BASE" "GitHub"; then
+if ! download_from "$GITHUB_BASE" "GitHub" "$GITHUB_TIMEOUT"; then
   warn "GitHub 下载失败或校验未通过，自动切换国内镜像"
-  download_from "$MIRROR_BASE" "国内镜像" ||
+  download_from "$MIRROR_BASE" "国内镜像" "$MIRROR_TIMEOUT" ||
     die "GitHub 与国内镜像均无法提供有效的 $PACKAGE_NAME"
 fi
 

--- a/packaging/runtime/install-agent-bootstrap.sh
+++ b/packaging/runtime/install-agent-bootstrap.sh
@@ -1,0 +1,104 @@
+#!/bin/sh
+set -eu
+
+VERSION=${WUHR_AGENT_VERSION:-1.0.0}
+GITHUB_BASE=${WUHR_AGENT_GITHUB_BASE:-"https://github.com/st-lzh/Wuhr-AI-ops/releases/download/v$VERSION"}
+MIRROR_BASE=${WUHR_AGENT_MIRROR_BASE:-"http://106.12.150.207/download"}
+TEMP_DIR=""
+
+log() {
+  printf '%s\n' "[Wuhr Agent 下载器] $*"
+}
+
+warn() {
+  printf '%s\n' "[Wuhr Agent 下载器][警告] $*" >&2
+}
+
+die() {
+  printf '%s\n' "[Wuhr Agent 下载器][错误] $*" >&2
+  exit 1
+}
+
+cleanup() {
+  if [ -n "$TEMP_DIR" ] && [ -d "$TEMP_DIR" ]; then
+    rm -rf "$TEMP_DIR"
+  fi
+}
+
+trap cleanup 0 HUP INT TERM
+
+case "$VERSION" in
+  ''|*[!A-Za-z0-9._-]*) die "版本号为空或含有非法字符：$VERSION" ;;
+esac
+
+OS=$(uname -s)
+case "$OS" in
+  Linux) OS_ID="linux" ;;
+  Darwin) OS_ID="darwin" ;;
+  *) die "不支持的操作系统：$OS" ;;
+esac
+
+ARCH=$(uname -m)
+case "$ARCH" in
+  x86_64|amd64) ARCH_ID="amd64" ;;
+  arm64|aarch64) ARCH_ID="arm64" ;;
+  *) die "不支持的 CPU 架构：$ARCH" ;;
+esac
+
+PACKAGE_NAME="wuhr-agent-$VERSION-$OS_ID-$ARCH_ID.tar.gz"
+CHECKSUM_NAME="$PACKAGE_NAME.sha256"
+TEMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/wuhr-agent-download.XXXXXX")
+
+download_file() {
+  url=$1
+  output=$2
+
+  if command -v curl >/dev/null 2>&1; then
+    curl --fail --location --silent --show-error \
+      --connect-timeout 15 --retry 2 --output "$output" "$url"
+  elif command -v wget >/dev/null 2>&1; then
+    wget --quiet --timeout=30 --tries=3 --output-document="$output" "$url"
+  else
+    die "缺少下载工具，请先安装 curl 或 wget"
+  fi
+}
+
+verify_package() {
+  (
+    cd "$TEMP_DIR"
+    if command -v sha256sum >/dev/null 2>&1; then
+      sha256sum -c "$CHECKSUM_NAME"
+    elif command -v shasum >/dev/null 2>&1; then
+      shasum -a 256 -c "$CHECKSUM_NAME"
+    else
+      die "缺少 SHA-256 校验工具"
+    fi
+  )
+}
+
+download_from() {
+  base_url=$1
+  source_name=$2
+
+  rm -f "$TEMP_DIR/$PACKAGE_NAME" "$TEMP_DIR/$CHECKSUM_NAME"
+  log "正在从${source_name}下载 $PACKAGE_NAME"
+  download_file "$base_url/$PACKAGE_NAME" "$TEMP_DIR/$PACKAGE_NAME" || return 1
+  download_file "$base_url/$CHECKSUM_NAME" "$TEMP_DIR/$CHECKSUM_NAME" || return 1
+  verify_package || return 1
+  log "${source_name}下载及 SHA-256 校验通过"
+}
+
+if ! download_from "$GITHUB_BASE" "GitHub"; then
+  warn "GitHub 下载失败或校验未通过，自动切换国内镜像"
+  download_from "$MIRROR_BASE" "国内镜像" ||
+    die "GitHub 与国内镜像均无法提供有效的 $PACKAGE_NAME"
+fi
+
+tar -C "$TEMP_DIR" -xzf "$TEMP_DIR/$PACKAGE_NAME"
+PACKAGE_DIR="$TEMP_DIR/wuhr-agent-$VERSION-$OS_ID-$ARCH_ID"
+LOCAL_INSTALLER="$PACKAGE_DIR/install-agent.sh"
+[ -f "$LOCAL_INSTALLER" ] || die "发布包缺少 install-agent.sh"
+chmod 0755 "$LOCAL_INSTALLER"
+
+log "已选择 os=$OS_ID arch=$ARCH_ID version=$VERSION"
+"$LOCAL_INSTALLER" "$@"

--- a/packaging/runtime/install-agent-bootstrap.sh
+++ b/packaging/runtime/install-agent-bootstrap.sh
@@ -4,6 +4,7 @@ set -eu
 VERSION=${WUHR_AGENT_VERSION:-1.0.0}
 GITHUB_BASE=${WUHR_AGENT_GITHUB_BASE:-"https://github.com/st-lzh/Wuhr-AI-ops/releases/download/v$VERSION"}
 MIRROR_BASE=${WUHR_AGENT_MIRROR_BASE:-"http://106.12.150.207/download"}
+DOWNLOAD_TIMEOUT=${WUHR_AGENT_DOWNLOAD_TIMEOUT:-30}
 TEMP_DIR=""
 
 log() {
@@ -30,6 +31,10 @@ trap cleanup 0 HUP INT TERM
 case "$VERSION" in
   ''|*[!A-Za-z0-9._-]*) die "版本号为空或含有非法字符：$VERSION" ;;
 esac
+case "$DOWNLOAD_TIMEOUT" in
+  ''|*[!0-9]*) die "下载超时必须是正整数秒数" ;;
+esac
+[ "$DOWNLOAD_TIMEOUT" -ge 1 ] || die "下载超时必须大于 0 秒"
 
 OS=$(uname -s)
 case "$OS" in
@@ -55,9 +60,12 @@ download_file() {
 
   if command -v curl >/dev/null 2>&1; then
     curl --fail --location --silent --show-error \
-      --connect-timeout 15 --retry 2 --output "$output" "$url"
+      --connect-timeout 10 --max-time "$DOWNLOAD_TIMEOUT" \
+      --retry 1 --retry-max-time "$DOWNLOAD_TIMEOUT" \
+      --output "$output" "$url"
   elif command -v wget >/dev/null 2>&1; then
-    wget --quiet --timeout=30 --tries=3 --output-document="$output" "$url"
+    wget --quiet --timeout=15 --read-timeout="$DOWNLOAD_TIMEOUT" \
+      --tries=2 --output-document="$output" "$url"
   else
     die "缺少下载工具，请先安装 curl 或 wget"
   fi

--- a/tests/unit/security-and-execution.test.ts
+++ b/tests/unit/security-and-execution.test.ts
@@ -21,6 +21,11 @@ import {
 import { assessAutomationRisk, nextCronDate } from '../../lib/operations/automationService'
 import { chunkRunbook, hashRunbookContent } from '../../lib/knowledge/runbookService'
 import { checkDockerRegistry } from '../../lib/artifacts/registryClient'
+import {
+  AGENT_INSTALLER_MIRROR_URL,
+  AGENT_INSTALLER_PRIMARY_URL,
+  buildAgentInstallCommand
+} from '../../lib/agentRelease'
 
 test('环境变量写入加密、读取遮罩并可在服务端还原', () => {
   const protectedValue = protectEnvironment({ API_TOKEN: 'secret-token', EMPTY: '' })
@@ -79,6 +84,17 @@ test('统一路由权限策略不会再让根路径通配所有模块', () => {
   assert.equal(grantsPermission('viewer', ['servers:read'], 'servers:write'), false)
   assert.equal(grantsPermission('manager', ['servers:all'], 'servers:write'), true)
   assert.equal(grantsPermission('admin', [], 'permissions:write'), true)
+})
+
+test('Agent 安装命令先用 GitHub、再回退国内镜像且拒绝非法端口', () => {
+  const command = buildAgentInstallCommand(2081)
+
+  assert.ok(command.indexOf(AGENT_INSTALLER_PRIMARY_URL) < command.indexOf(AGENT_INSTALLER_MIRROR_URL))
+  assert.match(command, /curl -fsSL/)
+  assert.match(command, /sh "\$tmp" --port=2081/)
+  assert.doesNotMatch(command, /\|\s*(ba)?sh/)
+  assert.throws(() => buildAgentInstallCommand(0), /1-65535/)
+  assert.throws(() => buildAgentInstallCommand(65536), /1-65535/)
 })
 
 test('作业风险识别强制覆盖破坏性命令，Cron 使用上海时区', () => {


### PR DESCRIPTION
## 变更内容

- 新增仅构建后端 Agent 的分架构发布脚本，输出 Linux/macOS、amd64/arm64 四个独立包
- 新增 GitHub 优先、国内 Nginx 镜像回退且强制 SHA-256 校验的在线安装器
- 统一平台内所有 Agent 安装命令，移除失效的旧 v2.0.0 下载地址
- 更新下载页和安装/发布文档，明确公开 Release 不上传前端镜像或后端源码
- 新增安装命令回退与端口校验单元测试

## 原因

此前公开发布资产包含不应上传的前端镜像，Agent 又使用合并包和失效下载地址，无法按客户系统架构精确下载，也没有 GitHub 失败后的自动镜像回退。

## 验证

- `npm exec tsc -- --noEmit`
- `npm run test:unit`（14/14 通过）
- 后端 `go test ./...` 全部通过
- 四种目标均完成 `CGO_ENABLED=0` 交叉编译
- 所有归档及 SHA-256 校验通过，归档扫描未发现前后端源码、环境文件或 Git 元数据
- 模拟 GitHub 下载失败，安装器成功回退本地镜像并完成对应架构 `--dry-run`
